### PR TITLE
Generalize fsspec instantiation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,3 +27,32 @@ Basic usage
 and other options. It can be edited just like any dictionary.
 
 For more in-depth usage, please refer to the documentation. This can be generated with :code:`make docs`.
+
+
+Authentication with Google Cloud Storage
+----------------------------------------
+
+Many of the examples in this repo refer to data stored in an Allen AI google
+cloud storage bucket, which is open to the public...but not for free.
+
+This package uses fsspec to access remote files. See their `configuration
+documentation`_ for details. If you do not typically access AI2 google cloud
+storage, you may need to enable requester pays, which you can do by setting the
+following environment variables::
+
+    export FSSPEC_GS_REQUESTER_PAYS=True
+    # the following will be set with `gcloud auth login`
+    export GOOGLE_CLOUD_PROJECT=<the project id to be charged>
+
+
+You can check your authentication in a python console like this::
+
+    >>> import google.auth
+    >>> google.auth.default()
+    (<google.oauth2.credentials.Credentials object at 0x7fdee0026dd0>, '<your project>')
+
+If you see both the credentials object and the project id, you are adequately
+authenticated for requester pays. If you are accessing a bucket owned by your
+project, then the project does not need to be set.
+
+.. _configuration documentation: https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -44,7 +44,7 @@ class _Location:
     def __init__(self, location: str) -> None:
         self.match = re.match(r"(?P<prefix>(?P<protocol>.*?)://)?", location)
         if self.match is None:
-            return f"protocol could not be inferred from {location}"
+            raise ValueError(f"protocol could not be inferred from {location}")
 
     def get_protocol(self) -> str:
         return self.match.group("protocol") or "file"

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import fsspec
+import re
 from ._exceptions import DelayedImportError
 from . import caching
 from concurrent.futures import ThreadPoolExecutor, Executor
@@ -22,10 +23,8 @@ def _get_fs(path: str) -> fsspec.AbstractFileSystem:
     mock this implementation, it is still used in modules which import using
     `from filesystem import get_fs`.
     """
-    if path.startswith("gs://"):
-        return fsspec.filesystem("gs", requester_pays=True)
-    else:
-        return fsspec.filesystem("file")
+    protocol = _Location(path).get_protocol()
+    return fsspec.filesystem(protocol)
 
 
 def isabs(path: str) -> bool:
@@ -41,15 +40,24 @@ def is_existing_absolute_path(path: str) -> bool:
     return isabs(path) and get_fs(path).exists(path)
 
 
+class _Location:
+    def __init__(self, location: str) -> None:
+        self.match = re.match(r"(?P<prefix>(?P<protocol>.*?)://)?", location)
+        if self.match is None:
+            return f"protocol could not be inferred from {location}"
+
+    def get_protocol(self) -> str:
+        return self.match.group("protocol") or "file"
+
+    def get_protocol_prefix(self) -> str:
+        return self.match.group("prefix") or ""
+
+
 def _get_protocol_prefix(location):
     """If a string starts with "<protocol>://"", return that part of the string.
     Otherwise, return an empty string.
     """
-    separator = "://"
-    if separator in location:
-        return location[: location.index(separator) + len(separator)]
-    else:
-        return ""
+    return _Location(location).get_protocol_prefix()
 
 
 def _get_path(location):

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,23 @@
+from fv3config.filesystem import _get_protocol_prefix, _Location
+
+
+def test__Location_get_protocol():
+    # copilot generated all of these cases magically!
+    assert _Location("gs://my-bucket/my_filename.txt").get_protocol() == "gs"
+    assert _Location("http://www.mysite.com/dir/file.nc").get_protocol() == "http"
+    assert _Location("memory:///some/path").get_protocol() == "memory"
+    assert _Location("file:///some/path").get_protocol() == "file"
+    assert _Location("/some/path").get_protocol() == "file"
+    assert _Location("some/path").get_protocol() == "file"
+    assert _Location("").get_protocol() == "file"
+
+
+def test__get_protocol_prefix():
+    # copilot generated all of these magically!
+    assert _get_protocol_prefix("gs://my-bucket/my_filename.txt") == "gs://"
+    assert _get_protocol_prefix("http://www.mysite.com/dir/file.nc") == "http://"
+    assert _get_protocol_prefix("memory:///some/path") == "memory://"
+    assert _get_protocol_prefix("file:///some/path") == "file://"
+    assert _get_protocol_prefix("/some/path") == ""
+    assert _get_protocol_prefix("some/path") == ""
+    assert _get_protocol_prefix("") == ""


### PR DESCRIPTION
get_fs does not support file systems other than gcsfs or file. It also
has special handling of requester_pays that breaks some typical
authentication patterns, where the key file is pointed to by
GOOGLE_APPLICATION_CREDENTIALS, but no default google project is set.

* Remove the special handling and generalize `get_fs` to work with any ffsspec filesystem

fsspec now offers a way to configure these flags via environment
variables. In this case requester pays can be turned on like this:

    export FSSPEC_GS_REQUESTER_PAYS=True

Resolves #143.