### PR TITLE
Make fv3config.config_to_asset_list public API

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ History
 Latest
 ------
 
+API Changes
+~~~~~~~~~~~
+- add ``fv3config.config_to_asset_list``
+- add ``fv3config.write_asset``
+
+
+
 v0.9.0 (2022-04-14)
 -------------------
 

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -24,7 +24,13 @@ from .config import (
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded
 from .fv3run import run_docker, run_native, run_kubernetes
-from ._asset_list import get_asset_dict, get_bytes_asset_dict, asset_list_from_path
+from ._asset_list import (
+    get_asset_dict,
+    get_bytes_asset_dict,
+    asset_list_from_path,
+    write_asset,
+)
+from ._asset_list_config import config_to_asset_list
 from .caching import CACHE_REMOTE_FILES, do_remote_caching, set_cache_dir, get_cache_dir
 
 

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -90,6 +90,15 @@ def get_bytes_asset_dict(
     }
 
 
+def get_directory_asset_dict(path: str):
+    """An asset representing an empty folder to be created
+
+    Args:
+       path: the directory to create relative to the rundir root
+    """
+    return {"target_name": "", "target_location": path, "directory": True}
+
+
 def _without_dot(path):
     if path == ".":
         return ""
@@ -156,6 +165,8 @@ def write_asset(asset, target_directory):
         logger.debug(f"Writing asset bytes to {target_path}.")
         with open(target_path, "wb") as f:
             f.write(asset["bytes"])
+    elif "directory" in asset:
+        return os.makedirs(target_path, exist_ok=True)
     else:
         raise ConfigError(
             "Cannot write asset. Asset must have either a `copy_method` or `bytes` key."

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -13,6 +13,7 @@ from fv3config._datastore import (
     get_data_table_filename,
 )
 from .config.diag_table import DiagTable
+from .config.namelist import config_to_namelist
 from .config._serialization import dump
 from ._exceptions import ConfigError
 from . import filesystem
@@ -34,6 +35,12 @@ def ensure_is_list(asset):
         return asset
     else:
         raise ConfigError("Asset must be a dict or list of dicts")
+
+
+def get_namelist_asset(config):
+    text = config_to_namelist(config)
+    data = text.encode()
+    return get_bytes_asset_dict(data, target_location="", target_name="input.nml")
 
 
 def get_orographic_forcing_asset_list(config):
@@ -289,6 +296,7 @@ def config_to_asset_list(config):
     asset_list.append(get_diag_table_asset(config))
     asset_list.append(get_data_table_asset(config))
     asset_list.append(get_fv3config_yaml_asset(config))
+    asset_list.append(get_namelist_asset(config))
     if "patch_files" in config:
         if is_dict_or_list(config["patch_files"]):
             asset_list += ensure_is_list(config["patch_files"])

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -96,7 +96,14 @@ def get_directory_asset_dict(path: str):
     Args:
        path: the directory to create relative to the rundir root
     """
-    return {"target_name": "", "target_location": path, "directory": True}
+    return {
+        # empty values need to satisfy later validation checks
+        "source_location": "",
+        "source_name": "",
+        "target_location": path,
+        "target_name": "",
+        "copy_method": "directory",
+    }
 
 
 def _without_dot(path):
@@ -165,8 +172,6 @@ def write_asset(asset, target_directory):
         logger.debug(f"Writing asset bytes to {target_path}.")
         with open(target_path, "wb") as f:
             f.write(asset["bytes"])
-    elif "directory" in asset:
-        return os.makedirs(target_path, exist_ok=True)
     else:
         raise ConfigError(
             "Cannot write asset. Asset must have either a `copy_method` or `bytes` key."
@@ -183,6 +188,8 @@ def copy_file_asset(asset, target_path):
     elif copy_method == "link":
         logger.debug(f"Linking asset from {source_path} to {target_path}.")
         link_file(source_path, target_path)
+    elif copy_method == "directory":
+        return os.makedirs(target_path, exist_ok=True)
     else:
         raise ConfigError(
             f"Behavior of copy_method {copy_method} not defined for {source_path} asset"

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -82,13 +82,14 @@ def get_data_table_asset(config):
 def get_diag_table_asset(config):
     """Return asset for diag_table"""
     if isinstance(config["diag_table"], DiagTable):
-        return get_bytes_asset_dict(
-            bytes(str(config["diag_table"]), "UTF-8"), ".", "diag_table"
-        )
+        data = bytes(str(config["diag_table"]), "UTF-8")
     else:
+        # TODO remove I/O from to top level
         diag_table_filename = get_diag_table_filename(config)
-        location, name = os.path.split(diag_table_filename)
-        return get_asset_dict(location, name, target_name="diag_table")
+        data = filesystem.cat(diag_table_filename)
+    return get_bytes_asset_dict(
+        data, ".", "diag_table"
+    )
 
 
 def get_field_table_asset(config):

--- a/fv3config/_asset_list_config.py
+++ b/fv3config/_asset_list_config.py
@@ -26,6 +26,7 @@ from ._asset_list import (
     get_asset_dict,
     get_bytes_asset_dict,
     get_patch_file_assets,
+    get_directory_asset_dict,
     asset_list_from_path,
 )
 from ._tables import update_diag_table_for_config
@@ -109,6 +110,9 @@ def _config_to_asset_generator(config):
     yield get_data_table_asset(config)
     yield get_fv3config_yaml_asset(config)
     yield get_namelist_asset(config)
+
+    # need to make restart directory
+    yield get_directory_asset_dict("RESTART")
 
 
 def config_to_asset_list(config):

--- a/fv3config/_asset_list_config.py
+++ b/fv3config/_asset_list_config.py
@@ -1,0 +1,108 @@
+"""Routines for converting an fv3config dict into a list of assets
+
+"""
+import io
+import os
+
+from ._datastore import (
+    get_orographic_forcing_directory,
+    get_base_forcing_directory,
+)
+from fv3config._datastore import (
+    get_field_table_filename,
+    get_diag_table_filename,
+    get_data_table_filename,
+)
+from .config.diag_table import DiagTable
+from .config.namelist import config_to_namelist
+from .config._serialization import dump
+from fv3config.config.initial_conditions import get_initial_conditions_asset_list
+from . import filesystem
+from ._asset_list import (
+    is_dict_or_list,
+    ensure_is_list,
+    get_asset_dict,
+    get_bytes_asset_dict,
+    get_patch_file_assets,
+    asset_list_from_path,
+)
+
+FV3CONFIG_YML_NAME = "fv3config.yml"
+
+
+def get_orographic_forcing_asset_list(config):
+    """Return asset_list for orographic forcing"""
+    if is_dict_or_list(config["orographic_forcing"]):
+        return ensure_is_list(config["orographic_forcing"])
+    else:
+        source_directory = get_orographic_forcing_directory(config)
+        return asset_list_from_path(
+            source_directory, target_location="INPUT", copy_method="link"
+        )
+
+
+def get_base_forcing_asset_list(config):
+    """Return asset_list for base forcing"""
+    if is_dict_or_list(config["forcing"]):
+        return ensure_is_list(config["forcing"])
+    else:
+        source_directory = get_base_forcing_directory(config)
+        return asset_list_from_path(source_directory, copy_method="link")
+
+
+def get_data_table_asset(config):
+    """Return asset for data_table"""
+    data_table_filename = get_data_table_filename(config)
+    location, name = os.path.split(data_table_filename)
+    return get_asset_dict(location, name, target_name="data_table")
+
+
+def get_diag_table_asset(config):
+    """Return asset for diag_table"""
+    if isinstance(config["diag_table"], DiagTable):
+        data = bytes(str(config["diag_table"]), "UTF-8")
+    else:
+        # TODO remove I/O from to top level
+        diag_table_filename = get_diag_table_filename(config)
+        data = filesystem.cat(diag_table_filename)
+    return get_bytes_asset_dict(data, ".", "diag_table")
+
+
+def get_field_table_asset(config):
+    """Return asset for field_table"""
+    field_table_filename = get_field_table_filename(config)
+    location, name = os.path.split(field_table_filename)
+    return get_asset_dict(location, name, target_name="field_table")
+
+
+def get_fv3config_yaml_asset(config):
+    """An asset containing this configuration"""
+    f = io.StringIO()
+    dump(config, f)
+    return get_bytes_asset_dict(
+        bytes(f.getvalue(), "UTF-8"),
+        target_location=".",
+        target_name=FV3CONFIG_YML_NAME,
+    )
+
+
+def config_to_asset_list(config):
+    """Convert a configuration dictionary to an asset list. The asset list
+    will contain all files for the run directory except the namelist."""
+    asset_list = []
+    asset_list += get_initial_conditions_asset_list(config)
+    asset_list += get_base_forcing_asset_list(config)
+    asset_list += get_orographic_forcing_asset_list(config)
+    asset_list.append(get_field_table_asset(config))
+    asset_list.append(get_diag_table_asset(config))
+    asset_list.append(get_data_table_asset(config))
+    asset_list.append(get_fv3config_yaml_asset(config))
+    asset_list.append(get_namelist_asset(config))
+    asset_list.extend(get_patch_file_assets(config))
+    return asset_list
+
+
+def get_namelist_asset(config):
+    text = config_to_namelist(config)
+    data = text.encode()
+    return get_bytes_asset_dict(data, target_location="", target_name="input.nml")

--- a/fv3config/_asset_list_config.py
+++ b/fv3config/_asset_list_config.py
@@ -66,8 +66,9 @@ def get_diag_table_asset(config):
     if isinstance(config["diag_table"], DiagTable):
         data = bytes(str(config["diag_table"]), "UTF-8")
     else:
-        # TODO remove I/O from to top level
         diag_table_filename = get_diag_table_filename(config)
+        # would be nice to avoid I/O here, but this I/O (e.g. for listing
+        # directories) is relative common in these routines
         data = filesystem.cat(diag_table_filename)
     return get_bytes_asset_dict(data, ".", "diag_table")
 

--- a/fv3config/_asset_list_config.py
+++ b/fv3config/_asset_list_config.py
@@ -86,20 +86,22 @@ def get_fv3config_yaml_asset(config):
     )
 
 
+def _config_to_asset_generator(config):
+    yield from get_initial_conditions_asset_list(config)
+    yield from get_base_forcing_asset_list(config)
+    yield from get_orographic_forcing_asset_list(config)
+    yield from get_patch_file_assets(config)
+    yield get_field_table_asset(config)
+    yield get_diag_table_asset(config)
+    yield get_data_table_asset(config)
+    yield get_fv3config_yaml_asset(config)
+    yield get_namelist_asset(config)
+
+
 def config_to_asset_list(config):
     """Convert a configuration dictionary to an asset list. The asset list
     will contain all files for the run directory except the namelist."""
-    asset_list = []
-    asset_list += get_initial_conditions_asset_list(config)
-    asset_list += get_base_forcing_asset_list(config)
-    asset_list += get_orographic_forcing_asset_list(config)
-    asset_list.append(get_field_table_asset(config))
-    asset_list.append(get_diag_table_asset(config))
-    asset_list.append(get_data_table_asset(config))
-    asset_list.append(get_fv3config_yaml_asset(config))
-    asset_list.append(get_namelist_asset(config))
-    asset_list.extend(get_patch_file_assets(config))
-    return asset_list
+    return list(_config_to_asset_generator(config))
 
 
 def get_namelist_asset(config):

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -4,6 +4,7 @@ from .caching import get_internal_cache_dir
 from .data import DATA_DIR
 from ._exceptions import ConfigError
 from . import filesystem
+from .filesystem import ensure_exists
 
 
 DATA_TABLE_OPTIONS = {
@@ -71,21 +72,6 @@ def get_base_forcing_directory(config):
         raise ConfigError("config dictionary must have a 'forcing' key")
     ensure_exists(config["forcing"], "forcing")
     return config["forcing"]
-
-
-def get_initial_conditions_directory(config):
-    """Return the string path of the initial conditions directory
-    specified by a config dictionary.
-    """
-    if "initial_conditions" not in config:
-        raise ConfigError("config dictionary must have an 'initial_conditions' key")
-    ensure_exists(config["initial_conditions"], "initial_conditions")
-    return config["initial_conditions"]
-
-
-def ensure_exists(location: str, location_name: str):
-    if not filesystem.get_fs(location).exists(location):
-        raise ConfigError(f"{location_name} location {location} does not exist")
 
 
 def check_if_data_is_downloaded():

--- a/fv3config/_tables.py
+++ b/fv3config/_tables.py
@@ -4,22 +4,19 @@ from ._exceptions import ConfigError
 package_directory = os.path.dirname(os.path.realpath(__file__))
 
 
-def update_diag_table_for_config(config, base_date, diag_table_filename):
+def update_diag_table_for_config(config, base_date, diag_table_contents: str):
     """Re-write first two lines of diag_table_filename with experiment_name
     and base_date from config dictionary.
 
     Args:
         config (dict): a configuration dictionary
         base_date (list): a list of 6 integers representing base_date
-        diag_table_filename (str): diag_table filename
+        diag_table_contents (str): the contents of the diag table file
     """
     if "experiment_name" not in config:
         raise ConfigError("config dictionary must have a 'experiment_name' key")
-    temporary_diag_table_filename = f"{diag_table_filename}_temporary"
-    with open(diag_table_filename) as diag_table:
-        lines = diag_table.read().splitlines()
-        lines[0] = config["experiment_name"]
-        lines[1] = " ".join([str(x) for x in base_date])
-        with open(temporary_diag_table_filename, "w") as temporary_diag_table:
-            temporary_diag_table.write("\n".join(lines))
-    os.replace(temporary_diag_table_filename, diag_table_filename)
+
+    lines = diag_table_contents.splitlines()
+    lines[0] = config["experiment_name"] + "\n"
+    lines[1] = " ".join([str(x) for x in base_date]) + "\n"
+    return "".join(lines)

--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -3,7 +3,8 @@ import re
 from datetime import timedelta
 from .._exceptions import ConfigError
 from .default import NAMELIST_DEFAULTS
-from .._asset_list import config_to_asset_list
+from .._asset_list import get_patch_file_assets
+from .initial_conditions import get_initial_conditions_asset_list
 from ..filesystem import get_fs
 
 
@@ -103,7 +104,9 @@ def _read_dates_from_coupler_res(coupler_res_filename):
 
 def _get_coupler_res_filename(config):
     """Return source path for coupler.res file, if it exists in config assets."""
-    asset_list = config_to_asset_list(config)
+    asset_list = get_initial_conditions_asset_list(config) + list(
+        get_patch_file_assets(config)
+    )
     source_path = None
     for item in asset_list:
         target_path = os.path.join(item["target_location"], item["target_name"])

--- a/fv3config/config/initial_conditions.py
+++ b/fv3config/config/initial_conditions.py
@@ -1,0 +1,22 @@
+from fv3config._exceptions import ConfigError
+from .._asset_list import is_dict_or_list, ensure_is_list, asset_list_from_path
+from ..filesystem import ensure_exists
+
+
+def get_initial_conditions_directory(config):
+    """Return the string path of the initial conditions directory
+    specified by a config dictionary.
+    """
+    if "initial_conditions" not in config:
+        raise ConfigError("config dictionary must have an 'initial_conditions' key")
+    ensure_exists(config["initial_conditions"], "initial_conditions")
+    return config["initial_conditions"]
+
+
+def get_initial_conditions_asset_list(config):
+    """Return asset_list for initial conditions. """
+    if is_dict_or_list(config["initial_conditions"]):
+        return ensure_is_list(config["initial_conditions"])
+    else:
+        source_directory = get_initial_conditions_directory(config)
+        return asset_list_from_path(source_directory, target_location="INPUT")

--- a/fv3config/config/namelist.py
+++ b/fv3config/config/namelist.py
@@ -1,4 +1,3 @@
-import os
 import io
 import f90nml
 from .._exceptions import InvalidFileError

--- a/fv3config/config/namelist.py
+++ b/fv3config/config/namelist.py
@@ -1,18 +1,19 @@
 import os
+import io
 import f90nml
 from .._exceptions import InvalidFileError
 
 
-def config_to_namelist(config, namelist_filename):
+def config_to_namelist(config) -> str:
     """Write the namelist of a configuration dictionary to a namelist file.
 
     Args:
         config (dict): a configuration dictionary
         namelist_filename (str): filename to write, will be overwritten if present
     """
-    if os.path.isfile(namelist_filename):
-        os.remove(namelist_filename)
-    f90nml.write(config["namelist"], namelist_filename)
+    f = io.StringIO()
+    f90nml.write(config["namelist"], f)
+    return f.getvalue()
 
 
 def config_from_namelist(namelist_filename):

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from .namelist import config_to_namelist
 from .._asset_list import write_assets_to_directory
 from .._tables import update_diag_table_for_config
 from .derive import get_time_configuration
@@ -22,12 +21,10 @@ def write_run_directory(config, target_directory):
         config = enable_nudging(config)
     write_assets_to_directory(config, target_directory)
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
-    base_date, _ = get_time_configuration(config)
 
     diag_table = pathlib.Path(target_directory, "diag_table")
+    base_date, _ = get_time_configuration(config)
     new_contents = update_diag_table_for_config(
         config, base_date, diag_table.read_text()
     )
     diag_table.write_text(new_contents)
-    namelist_contents = config_to_namelist(config)
-    pathlib.Path(target_directory, "input.nml").write_text(namelist_contents)

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -1,6 +1,7 @@
 import logging
 import os
-from .._asset_list import write_assets_to_directory
+from .._asset_list import write_asset
+from .._asset_list_config import config_to_asset_list
 from .._tables import update_diag_table_for_config
 from .derive import get_time_configuration
 from .nudging import enable_nudging
@@ -19,7 +20,11 @@ def write_run_directory(config, target_directory):
     logger.debug(f"Writing run directory to {target_directory}")
     if config["namelist"]["fv_core_nml"].get("nudge", False):
         config = enable_nudging(config)
-    write_assets_to_directory(config, target_directory)
+
+    asset_list = config_to_asset_list(config)
+    for asset in asset_list:
+        write_asset(asset, target_directory)
+
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
 
     diag_table = pathlib.Path(target_directory, "diag_table")

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -5,6 +5,7 @@ from .._asset_list import write_assets_to_directory
 from .._tables import update_diag_table_for_config
 from .derive import get_time_configuration
 from .nudging import enable_nudging
+import pathlib
 
 logger = logging.getLogger("fv3config")
 
@@ -22,7 +23,10 @@ def write_run_directory(config, target_directory):
     write_assets_to_directory(config, target_directory)
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
     base_date, _ = get_time_configuration(config)
-    update_diag_table_for_config(
-        config, base_date, os.path.join(target_directory, "diag_table")
+
+    diag_table = pathlib.Path(target_directory, "diag_table")
+    new_contents = update_diag_table_for_config(
+        config, base_date, diag_table.read_text()
     )
+    diag_table.write_text(new_contents)
     config_to_namelist(config, os.path.join(target_directory, "input.nml"))

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from .._asset_list import write_asset
 from .._asset_list_config import config_to_asset_list
 
@@ -15,8 +14,5 @@ def write_run_directory(config, target_directory):
     """
     logger.debug(f"Writing run directory to {target_directory}")
     asset_list = config_to_asset_list(config)
-
     for asset in asset_list:
         write_asset(asset, target_directory)
-
-    os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -2,10 +2,6 @@ import logging
 import os
 from .._asset_list import write_asset
 from .._asset_list_config import config_to_asset_list
-from .._tables import update_diag_table_for_config
-from .derive import get_time_configuration
-from .nudging import enable_nudging
-import pathlib
 
 logger = logging.getLogger("fv3config")
 
@@ -18,18 +14,9 @@ def write_run_directory(config, target_directory):
         target_directory (str): target directory, will be created if it does not exist
     """
     logger.debug(f"Writing run directory to {target_directory}")
-    if config["namelist"]["fv_core_nml"].get("nudge", False):
-        config = enable_nudging(config)
-
     asset_list = config_to_asset_list(config)
+
     for asset in asset_list:
         write_asset(asset, target_directory)
 
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
-
-    diag_table = pathlib.Path(target_directory, "diag_table")
-    base_date, _ = get_time_configuration(config)
-    new_contents = update_diag_table_for_config(
-        config, base_date, diag_table.read_text()
-    )
-    diag_table.write_text(new_contents)

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -29,4 +29,5 @@ def write_run_directory(config, target_directory):
         config, base_date, diag_table.read_text()
     )
     diag_table.write_text(new_contents)
-    config_to_namelist(config, os.path.join(target_directory, "input.nml"))
+    namelist_contents = config_to_namelist(config)
+    pathlib.Path(target_directory, "input.nml").write_text(namelist_contents)

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -134,6 +134,12 @@ def get_file(source_filename: str, dest_filename: str, cache: bool = None):
         _get_file_cached(source_filename, dest_filename)
 
 
+def cat(url: str) -> bytes:
+    """read a remote file as bytes"""
+    fs = _get_fs(url)
+    return fs.cat(url)
+
+
 def _get_file_uncached(source_filename, dest_filename):
     fs = get_fs(source_filename)
     fs.get(source_filename, dest_filename)

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -4,6 +4,7 @@ import fsspec
 import re
 from ._exceptions import DelayedImportError
 from . import caching
+from ._exceptions import ConfigError
 from concurrent.futures import ThreadPoolExecutor, Executor
 
 
@@ -185,6 +186,11 @@ def _get_cache_filename(source_filename):
         cache_label = "rel"
     path_in_cache = cache_dir / cache_label / prefix / path_no_root
     return path_in_cache.as_posix()
+
+
+def ensure_exists(location: str, location_name: str):
+    if not get_fs(location).exists(location):
+        raise ConfigError(f"{location_name} location {location} does not exist")
 
 
 open = fsspec.open

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -7,16 +7,18 @@ import tempfile
 import fv3config
 from fv3config._asset_list import (
     is_dict_or_list,
-    get_data_table_asset,
-    get_diag_table_asset,
-    get_field_table_asset,
-    get_fv3config_yaml_asset,
     get_asset_dict,
     get_bytes_asset_dict,
     ensure_is_list,
     asset_list_from_path,
     check_asset_has_required_keys,
     write_asset,
+)
+from fv3config._asset_list_config import (
+    get_data_table_asset,
+    get_diag_table_asset,
+    get_field_table_asset,
+    get_fv3config_yaml_asset,
 )
 import yaml
 import pytest

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -4,11 +4,14 @@ import unittest
 import os
 import shutil
 import tempfile
+
+
 import fv3config
 from fv3config._asset_list import (
     is_dict_or_list,
     get_asset_dict,
     get_bytes_asset_dict,
+    get_directory_asset_dict,
     ensure_is_list,
     asset_list_from_path,
     check_asset_has_required_keys,
@@ -354,6 +357,13 @@ def test_get_diag_table_asset_from_file(tmp_path: pathlib.Path):
     config["diag_table"] = diag_table_path.as_posix()
     diag_table_asset = get_diag_table_asset(config)
     assert diag_table_asset == expected
+
+
+def test_directory_asset(tmp_path: pathlib.Path):
+    asset = get_directory_asset_dict("some_dir")
+    write_asset(asset, str(tmp_path))
+    expected_directory = tmp_path / "some_dir"
+    assert expected_directory.is_dir()
 
 
 if __name__ == "__main__":

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -1,4 +1,5 @@
 import datetime
+import pathlib
 import unittest
 import os
 import shutil
@@ -144,17 +145,12 @@ class AssetListTests(unittest.TestCase):
         self.assertFalse(is_dict_or_list(1))
 
     def test_get_data_table_asset_default(self):
-        config = DEFAULT_CONFIG.copy()
+        config = c12_config()
         data_table_asset = get_data_table_asset(config)
         self.assertEqual(data_table_asset, DEFAULT_DATA_TABLE_ASSET)
 
-    def test_get_diag_table_asset_default(self):
-        config = DEFAULT_CONFIG.copy()
-        diag_table_asset = get_diag_table_asset(config)
-        self.assertEqual(diag_table_asset, DEFAULT_DIAG_TABLE_ASSET)
-
     def test_get_field_table_asset_default(self):
-        config = DEFAULT_CONFIG.copy()
+        config = c12_config()
         field_table_asset = get_field_table_asset(config)
         self.assertEqual(field_table_asset, DEFAULT_FIELD_TABLE_ASSET)
 
@@ -345,6 +341,17 @@ def test_get_diag_table_asset_from_class(tmpdir):
         loaded = f.read()
 
     assert loaded == str(diag_table)
+
+
+def test_get_diag_table_asset_from_file(tmp_path: pathlib.Path):
+    config = c12_config()
+    diag_table_path = tmp_path / "diag_table"
+    contents = b"hahahahahahahahah no one cares what this is"
+    expected = get_bytes_asset_dict(contents, ".", "diag_table")
+    diag_table_path.write_bytes(contents)
+    config["diag_table"] = diag_table_path.as_posix()
+    diag_table_asset = get_diag_table_asset(config)
+    assert diag_table_asset == expected
 
 
 if __name__ == "__main__":

--- a/tests/test_forcingdata.py
+++ b/tests/test_forcingdata.py
@@ -6,15 +6,15 @@ import fv3config.caching
 from fv3config._datastore import (
     get_base_forcing_directory,
     get_orographic_forcing_directory,
-    get_initial_conditions_directory,
     resolve_option,
 )
-from fv3config._asset_list import (
+from fv3config.config.initial_conditions import get_initial_conditions_directory
+from fv3config._asset_list_config import (
     get_orographic_forcing_asset_list,
     get_base_forcing_asset_list,
-    get_initial_conditions_asset_list,
-    write_asset_list,
 )
+from fv3config.config.initial_conditions import get_initial_conditions_asset_list
+from fv3config._asset_list import write_asset
 from .mocks import c12_config
 
 TEST_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
@@ -100,14 +100,16 @@ class ForcingTests(unittest.TestCase):
         rundir = self.make_run_directory("test_rundir")
         config = c12_config()
         asset_list = get_base_forcing_asset_list(config)
-        write_asset_list(asset_list, rundir)
+        for asset in asset_list:
+            write_asset(asset, rundir)
         self.assert_subpaths_present(rundir, required_base_forcing_filenames)
 
     def test_write_default_orographic_forcing_directory(self):
         rundir = self.make_run_directory("test_rundir")
         config = c12_config()
         asset_list = get_orographic_forcing_asset_list(config)
-        write_asset_list(asset_list, rundir)
+        for asset in asset_list:
+            write_asset(asset, rundir)
         self.assert_subpaths_present(rundir, required_orographic_forcing_filenames)
 
     def test_zero_resolution_orographic_forcing_directory(self):
@@ -130,7 +132,8 @@ class ForcingTests(unittest.TestCase):
         rundir = self.make_run_directory("test_rundir")
         config = c12_config()
         asset_list = get_initial_conditions_asset_list(config)
-        write_asset_list(asset_list, rundir)
+        for asset in asset_list:
+            write_asset(asset, rundir)
         self.assert_subpaths_present(
             rundir, required_default_initial_conditions_filenames
         )

--- a/tests/test_namelist.py
+++ b/tests/test_namelist.py
@@ -119,51 +119,20 @@ class ConfigDictTests(unittest.TestCase):
         self.assertEqual(config, all_types_dict)
 
     def test_empty_write_to_namelist(self):
-        rundir = self.make_run_directory("test_rundir")
-        namelist_filename = os.path.join(rundir, "input.nml")
         config = {"namelist": {}}
-        config_to_namelist(config, namelist_filename)
-        self.assertTrue(os.path.isfile(namelist_filename))
-        with open(namelist_filename, "r") as namelist_file:
-            written_namelist = namelist_file.read()
-        self.assertEqual(written_namelist, "")
+        text = config_to_namelist(config)
+        self.assertEqual(text, "")
 
     def test_one_item_write_to_namelist(self):
-        rundir = self.make_run_directory("test_rundir")
-        namelist_filename = os.path.join(rundir, "input.nml")
         config = {"namelist": deepcopy(one_item_dict)}
-        config_to_namelist(config, namelist_filename)
-        self.assertTrue(os.path.isfile(namelist_filename))
-        with open(namelist_filename, "r") as namelist_file:
-            written_namelist = namelist_file.read()
-        self.assertEqual(written_namelist, one_item_namelist)
+        text = config_to_namelist(config)
+        self.assertEqual(text, one_item_namelist)
 
     def test_many_items_write_to_namelist(self):
-        rundir = self.make_run_directory("test_rundir")
-        namelist_filename = os.path.join(rundir, "input.nml")
         config = {"namelist": deepcopy(all_types_dict)}
-        config_to_namelist(config, namelist_filename)
-        self.assertTrue(os.path.isfile(namelist_filename))
-        with open(namelist_filename, "r") as namelist_file:
-            written_lines = namelist_file.readlines()
-        target_lines = [line + "\n" for line in all_types_namelist.split("\n") if line]
-        self.assertEqual(len(written_lines), len(target_lines))
-        self.assertEqual(written_lines[0], target_lines[0])
-        self.assertEqual(
-            set(written_lines[1:6]), set(target_lines[1:6])
-        )  # order doesn't matter
-        self.assertEqual(written_lines[6:], target_lines[6:])
-
-    def test_write_to_existing_namelist(self):
-        rundir = self.make_run_directory("test_rundir")
-        namelist_filename = os.path.join(rundir, "input.nml")
-        with open(namelist_filename, "w") as f:
-            f.write(one_item_namelist)
-        config = {"namelist": deepcopy(all_types_dict)}
-        config_to_namelist(config, namelist_filename)
-        with open(namelist_filename, "r") as namelist_file:
-            written_lines = namelist_file.readlines()
-        target_lines = [line + "\n" for line in all_types_namelist.split("\n") if line]
+        text = config_to_namelist(config)
+        written_lines = text.splitlines()
+        target_lines = [line for line in all_types_namelist.split("\n") if line]
         self.assertEqual(len(written_lines), len(target_lines))
         self.assertEqual(written_lines[0], target_lines[0])
         self.assertEqual(

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -129,10 +129,9 @@ class TableTests(unittest.TestCase):
             get_data_table_filename(empty_config)
 
     def test_update_diag_table_from_empty_config(self):
-        rundir = self.make_run_directory("rundir")
         with self.assertRaises(ConfigError):
             update_diag_table_for_config(
-                empty_config, valid_current_date, os.path.join(rundir, "source")
+                empty_config, valid_current_date, "doesn't matter"
             )
 
     def test__read_dates_from_coupler_res(self):
@@ -207,14 +206,11 @@ class TableTests(unittest.TestCase):
         config["experiment_name"] = "diag_table_test"
         config["namelist"]["coupler_nml"]["force_date_from_namelist"] = True
         config["namelist"]["coupler_nml"]["current_date"] = valid_current_date
-        rundir = self.make_run_directory("test_rundir")
-        diag_table_filename = os.path.join(rundir, "diag_table")
-        with open(diag_table_filename, "w") as f:
-            f.write(diag_table_test_in)
         base_date, _ = get_time_configuration(config)
-        update_diag_table_for_config(config, base_date, diag_table_filename)
-        with open(diag_table_filename) as f:
-            self.assertEqual(diag_table_test_out, f.read())
+        assert (
+            update_diag_table_for_config(config, base_date, diag_table_test_in)
+            == diag_table_test_out
+        )
 
 
 def test_get_coupler_res_filename_from_dir():


### PR DESCRIPTION
I would like to enable wandb (and other metadata tracking) integrations for assets supported by fv3config. The "asset list" is the natural target for this, but is not currently a complete representation of the config dict since there is lingering logic in the `write_run_directory` function.

* push all config-handling logic into `config_to_asset_list`
* make `config_to_asset_list` public API

This will allow usages like this downstream:
```
assets = fv3config.config_to_asset_list(config)
for asset in assets:
    if asset["source_location"].startswith("wandb://"):
        artifact = run.use_artifact(...asset)
        path = artifact.download()
        asset["source_location"] = path
    fv3config.write_asset(asset, "rundir")
```

To reviewers: I recommend reviewing commit-by-commit. I tried to isolate the refactors into coherent commits, and it should be much easier to follow that way.