### PR TITLE
Update instructions for requester pays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ documentation`_ for details. If you do not typically access AI2 google cloud
 storage, you may need to enable requester pays, which you can do by setting the
 following environment variables::
 
-    export FSSPEC_GS_REQUESTER_PAYS=True
+    export FSSPEC_GS_REQUESTER_PAYS=<the project id to be charged>
     # the following will be set with `gcloud auth login`
     export GOOGLE_CLOUD_PROJECT=<the project id to be charged>
 


### PR DESCRIPTION
The `FSSPEC_GS_REQUESTER_PAYS` environment variable is always treated as a string, which is interpreted as the project id rather than a boolean flag (see [here](https://github.com/fsspec/gcsfs/blob/e4c16db7f59e0f243965f015e95996f9e7fe9665/gcsfs/core.py#L339-L344)).  Therefore when setting the `requester_pays` option via the environment variable, one must always use the project id.

### Minimal example of the issue
```
$ export FSSPEC_GS_REQUESTER_PAYS=True
$ python
>>> import fsspec
>>> url = "gs://vcm-fv3config/config/yaml/default/v0.3/fv3config.yml"
>>> fs, *_ = fsspec.get_fs_token_paths(url)
>>> fs.requester_pays
'True'
>>> len(fs.cat(url))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/fsspec/asyn.py", line 85, in wrapper
    return sync(self.loop, func, *args, **kwargs)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/fsspec/asyn.py", line 65, in sync
    raise return_result
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/fsspec/asyn.py", line 25, in _runner
    result[0] = await coro
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/fsspec/asyn.py", line 397, in _cat
    raise ex
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/asyncio/tasks.py", line 455, in wait_for
    return await fut
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/gcsfs/core.py", line 768, in _cat_file
    headers, out = await self._call("GET", u2, headers=head)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/gcsfs/core.py", line 392, in _call
    status, headers, info, contents = await self._request(
  File "<decorator-gen-2>", line 2, in _request
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/gcsfs/retry.py", line 115, in retry_request
    return await func(*args, **kwargs)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/gcsfs/core.py", line 384, in _request
    validate_response(status, contents, path, args)
  File "/home/spencerc/miniconda3/envs/fv3net-testing/lib/python3.8/site-packages/gcsfs/retry.py", line 96, in validate_response
    raise IOError("Forbidden: %s\n%s" % (path, msg))
OSError: Forbidden: https://storage.googleapis.com/download/storage/v1/b/vcm-fv3config/o/config%2Fyaml%2Fdefault%2Fv0.3%2Ffv3config.yml?alt=media
The account for bucket &quot;vcm-fv3config&quot; has not enabled billing.
```

### Minimal example of the solution
```
$ export FSSPEC_GS_REQUESTER_PAYS=vcm-ml
$ python
>>> import fsspec
>>> url = "gs://vcm-fv3config/config/yaml/default/v0.3/fv3config.yml"
>>> fs, *_ = fsspec.get_fs_token_paths(url)
>>> fs.requester_pays
'vcm-ml'
>>> len(fs.cat(url))
5660
```